### PR TITLE
Fix reset of course module

### DIFF
--- a/lang/de/opencast.php
+++ b/lang/de/opencast.php
@@ -56,7 +56,6 @@ $string['notanswered'] = 'Noch nicht beantwortet';
 $string['notopenyet'] = 'Diese Aktivität steht erst per {$a} zur Verfügung';
 $string['pluginadministration'] = 'SWITCHcast-Administration';
 $string['pluginname'] = 'OpenCast';
-$string['timerestrict'] = 'Beschränkt Antworten auf diese Zeitperiode';
 $string['viewallresponses'] = '{$a} Antworten zeigen';
 $string['withselected'] = 'Mit ausgewählten';
 $string['yourselection'] = 'Ihre Auswahl';

--- a/lang/en/opencast.php
+++ b/lang/en/opencast.php
@@ -55,7 +55,6 @@ $string['notanswered'] = 'Not answered yet';
 $string['notopenyet'] = 'Sorry, this activity is not available until {$a}';
 $string['pluginadministration'] = 'SWITCHcast administration';
 $string['pluginname'] = 'OpenCast';
-$string['timerestrict'] = 'Restrict answering to this time period';
 $string['viewallresponses'] = 'View {$a} responses';
 $string['withselected'] = 'With selected';
 $string['yourselection'] = 'Your selection';

--- a/lang/fr/opencast.php
+++ b/lang/fr/opencast.php
@@ -55,7 +55,6 @@ $string['notanswered'] = 'Pas encore répondu';
 $string['notopenyet'] = 'Désolé, cette activité n\'est pas disponible avant {$a}.';
 $string['pluginadministration'] = 'Administration SWITCHcast';
 $string['pluginname'] = 'OpenCast';
-$string['timerestrict'] = 'Limiter les réponses à cette période';
 $string['viewallresponses'] = 'Visualiser {$a} réponses';
 $string['withselected'] = 'Avec la sélection';
 $string['yourselection'] = 'Votre sélection';

--- a/lib.php
+++ b/lib.php
@@ -72,11 +72,6 @@ function opencast_add_instance($opencast) {
         $scast->update();
     }
 
-    if (empty($opencast->timerestrict)) {
-        $opencast->timeopen = 0;
-        $opencast->timeclose = 0;
-    }
-
     $opencast->id = $DB->insert_record('opencast', $opencast);
 
     $completiontimeexpected = !empty($opencast->completionexpected) ? $opencast->completionexpected : null;
@@ -118,11 +113,6 @@ function opencast_update_instance($opencast) {
     $mod_opencast_update = $scast->update();
 
     $opencast->ext_id = $scast->getExtId();
-
-    if (empty($opencast->timerestrict)) {
-        $opencast->timeopen = 0;
-        $opencast->timeclose = 0;
-    }
 
     $moodle_update = $DB->update_record('opencast', $opencast);
 
@@ -218,12 +208,6 @@ function opencast_reset_userdata($data) {
         $status[] = [
                 'component' => $componentstr, 'item' => get_string('removeclipmembers', 'opencast'), 'error' => false
         ];
-    }
-
-    // updating dates - shift may be negative too
-    if ($data->timeshift) {
-        shift_course_mod_dates('opencast', ['timeopen', 'timeclose'], $data->timeshift, $data->courseid);
-        $status[] = ['component' => $componentstr, 'item' => get_string('datechanged'), 'error' => false];
     }
 
     return $status;


### PR DESCRIPTION
When resetting `mod_opencast` instances through the API, sometimes this error can occur:

```
Unknown column 'timeopen' in 'where clause'
UPDATE mdl_opencast
                          SET timeopen = timeopen + ?
                        WHERE course=? AND timeopen<>0
[array (
  0 => 3600,
  1 => 3311,
)]
```

This is because this line will ask Moodle to update fields that don't exist:
https://github.com/ndunand/moodle-mod_opencast/blob/master/lib.php#L225
```
    // updating dates - shift may be negative too
    if ($data->timeshift) {
        shift_course_mod_dates('opencast', ['timeopen', 'timeclose'], $data->timeshift, $data->courseid);
        $status[] = ['component' => $componentstr, 'item' => get_string('datechanged'), 'error' => false];
    }
```

My proposal is to completely remove all references to these fields that are not installed in the DB (not present in `db/install.xml`).